### PR TITLE
Refine grid and validation button styling

### DIFF
--- a/frontend/components/Grid.vue
+++ b/frontend/components/Grid.vue
@@ -183,28 +183,28 @@ defineExpose({ clearAll, takeBack })
 }
 
 .TW {
-  background-color: #CB514E;
+  background: linear-gradient(to bottom right, #CB514E, #A94442);
   color: #fff;
 }
 
 .DW,
 .CENTER {
-  background-color: #C18AB3;
+  background: linear-gradient(to bottom right, #C18AB3, #9C6F9E);
   color: #fff;
 }
 
 .TL {
-  background-color: #87B5D2;
+  background: linear-gradient(to bottom right, #87B5D2, #5C8EAB);
   color: #fff;
 }
 
 .DL {
-  background-color: #90caf9;
+  background: linear-gradient(to bottom right, #90caf9, #5a9bdc);
   color: #fff;
 }
 
 .use {
-  background-color: #EBBF56;
+  background: linear-gradient(to bottom right, #EBBF56, #D6A63B);
   color: #000;
 }
 </style>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -25,27 +25,38 @@ body {
 
 .validation {
   display: flex;
-  margin-top: 10px;
   justify-content: center;
+  margin-top: 10px;
+}
 
-  button {
-    margin: 0 5px;
-    background-color: #F29C3F;
-    color: #fff;
-    border: none;
-    padding: 0.5rem 1rem;
-    text-decoration: none;
-    cursor: pointer;
-    border-radius: 10px;
-  }
+.validation button {
+  margin: 0 5px;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 10px;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(to bottom, #F6BA79, #F29C3F);
+  box-shadow: 0 4px 0 #c7762e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  text-decoration: none;
+}
 
-  button:hover {
-    background-color: #F6BA79;
-  }
+.validation button:hover {
+  background: linear-gradient(to bottom, #F9C68A, #F6BA79);
+}
 
-  svg {
-    width: 20px;
-  }
+.validation button:active {
+  box-shadow: 0 2px 0 #c7762e;
+  transform: translateY(2px);
+}
+
+.validation svg {
+  width: 20px;
+  height: 20px;
 }
 
 .scrabble-grid {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -73,7 +73,7 @@ body {
   width: 30px;
   height: 30px;
   border: 1px solid #333;
-  background: var(--color-primary);
+  background: linear-gradient(to bottom, #F1D87A, #deb317);
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- Center validation buttons and give them a plastic look with a subtle gradient and active press effect
- Add soft color gradients to grid cells for better visual consistency

## Testing
- `npm test` *(fails: package.json not found)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894fe26421c8327b8c0a5b657368a2d