### PR TITLE
Fix single tile orientation when extending words

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -211,7 +211,19 @@ def place_tiles(placements: List[Tuple[int, int, str, bool]]) -> int:
     cols = {c for _, c, _, _ in placements}
     if len(rows) != 1 and len(cols) != 1:
         raise ValueError("Tiles must be in a single row or column")
-    horizontal = len(rows) == 1
+
+    # When a single tile is played, infer orientation from neighbouring tiles
+    if len(placements) == 1:
+        r, c, _, _ = placements[0]
+        if (
+            (r > 0 and board[r - 1][c] is not None)
+            or (r < BOARD_SIZE - 1 and board[r + 1][c] is not None)
+        ):
+            horizontal = False
+        else:
+            horizontal = True
+    else:
+        horizontal = len(rows) == 1
 
     for r, c, letter, _ in placements:
         if board[r][c] is not None:

--- a/tests/test_place_tiles.py
+++ b/tests/test_place_tiles.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import backend.game as g
+
+def test_single_tile_vertical_word():
+    g.reset_game()
+    g.place_tiles([(7, 7, 'H', False), (7, 8, 'A', False)])
+    score = g.place_tiles([(8, 7, 'E', False)])
+    assert score > 0
+    assert g.board[7][7] == 'H'
+    assert g.board[8][7] == 'E'


### PR DESCRIPTION
## Summary
- infer orientation from neighbouring tiles when only one tile is placed
- add regression test for vertical extension of an existing word

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68971654b2c08327a65c21bdde3758b9