### PR TITLE
Ensure game board updates and game fetch returns full state

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -143,7 +143,7 @@
           rack.value = data.rack
           placements.value = []
           result.value = ''
-          data.tiles.forEach(t => gameRef.value.gridRef.setTile(t.row, t.col, t.letter))
+          data.tiles.forEach(t => gameRef.value.gridRef.value.setTile(t.row, t.col, t.letter))
         }
 
         async function finishGame() {
@@ -177,7 +177,7 @@
             const insert = from < idx ? idx - 1 : idx
             rack.value.splice(insert, 0, tile)
           } else if (data.source === 'board') {
-            const letter = gameRef.value.gridRef.takeBack(data.row, data.col)
+            const letter = gameRef.value.gridRef.value.takeBack(data.row, data.col)
             if (!letter) return
             const placementIdx = placements.value.findIndex(p => p.row === data.row && p.col === data.col)
             if (placementIdx !== -1) placements.value.splice(placementIdx, 1)
@@ -206,7 +206,7 @@
         }
 
         function clearMove() {
-          gameRef.value.gridRef.clearAll(placements.value)
+          gameRef.value.gridRef.value.clearAll(placements.value)
           placements.value.forEach(p => rack.value.push(p.letter))
           placements.value = []
         }


### PR DESCRIPTION
## Summary
- Display tiles from saved games by dereferencing the grid component reference when loading a game
- Return complete game state (rack, tiles, bag count, scores, etc.) in `/game` to avoid 500 errors

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68977e2f60208327a8f122e197691ced