### PR TITLE
Handle opponent score display and test score reporting

### DIFF
--- a/backend/tests/test_scores.py
+++ b/backend/tests/test_scores.py
@@ -1,0 +1,53 @@
+"""Additional tests for score reporting."""
+import os
+import pathlib
+import random
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from backend.database import Base, SessionLocal, engine  # type: ignore
+from backend.main import (
+    CreateGameRequest,
+    JoinGameRequest,
+    MoveRequest,
+    create_game,
+    join_game,
+    play_move,
+    get_game_state,
+    start_game,
+)  # type: ignore
+
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def _setup_game() -> tuple[int, int, int, list[str]]:
+    random.seed(0)
+    with SessionLocal() as db:
+        game_id = create_game(CreateGameRequest(max_players=2), db=db)["game_id"]
+    with SessionLocal() as db:
+        p1 = join_game(game_id, JoinGameRequest(user_id=1), db=db)["player_id"]
+    with SessionLocal() as db:
+        p2 = join_game(game_id, JoinGameRequest(user_id=2), db=db)["player_id"]
+    with SessionLocal() as db:
+        start_data = start_game(game_id, seed=0, db=db)
+    rack1 = next(p["rack"] for p in start_data["players"] if p["player_id"] == p1)
+    return game_id, p1, p2, rack1
+
+
+def test_scores_report_both_players() -> None:
+    game_id, p1, p2, rack1 = _setup_game()
+    placements = [
+        {"row": 7, "col": 7, "letter": rack1[1], "blank": False},
+        {"row": 7, "col": 8, "letter": rack1[3], "blank": False},
+        {"row": 7, "col": 9, "letter": rack1[2], "blank": False},
+    ]
+    with SessionLocal() as db:
+        play_move(game_id, MoveRequest(player_id=p1, placements=placements), db=db)
+    with SessionLocal() as db:
+        state = get_game_state(game_id, player_id=p2, db=db)
+    assert state.scores[p1] > 0
+    assert state.scores[p2] == 0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -152,7 +152,8 @@
           placements.value = []
           result.value = ''
           score.value = data.scores[game.player_id] || 0
-          score_adversaire.value = data.scores[game.player_id] || 0
+          const adversaryId = Number(Object.keys(data.scores).find(id => Number(id) !== game.player_id))
+          score_adversaire.value = adversaryId ? data.scores[adversaryId] : 0
           if (gameRef.value?.gridRef?.value) {
             data.tiles.forEach(t =>
               gameRef.value.gridRef.value.setTile(t.row, t.col, t.letter)
@@ -274,7 +275,8 @@
           const stateData = await stateRes.json()
           rack.value = stateData.rack
           score.value = stateData.scores[currentGame.value.player_id] || 0
-          score_adversaire.value = stateData.scores[currentGame.value.player_id] || 0
+          const advId = Number(Object.keys(stateData.scores).find(id => Number(id) !== currentGame.value.player_id))
+          score_adversaire.value = advId ? stateData.scores[advId] : 0
         }
 
         function passTurn() {


### PR DESCRIPTION
## Summary
- fix opponent score not displayed by selecting other player ID
- verify scores for both players are reported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988a3c472883279d8544ac7f88d18b