### PR TITLE
Handle blank tile letter choice and scoring

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -183,7 +183,7 @@ def _score_word(coords: List[Tuple[int, int]], new_tiles: Iterable[Tuple[int, in
     score = 0
     for r, c in coords:
         letter = board[r][c]
-        letter_score = LETTER_POINTS.get(letter.upper(), 0)
+        letter_score = 0 if letter.islower() else LETTER_POINTS.get(letter.upper(), 0)
         if (r, c) in new_set:
             bonus = BONUS[r][c]
             if bonus == "DL":

--- a/backend/main.py
+++ b/backend/main.py
@@ -202,7 +202,7 @@ def _maybe_play_bot(
             player_id=bot_player.id,
             x=r,
             y=c,
-            letter=letter.upper(),
+            letter=letter.lower() if blank else letter.upper(),
         )
         db.add(tile)
         ltr = "?" if blank else letter.upper()
@@ -435,7 +435,7 @@ def play_move(game_id: int, req: MoveRequest, db: Session = Depends(get_db)) -> 
             player_id=req.player_id,
             x=p.row,
             y=p.col,
-            letter=p.letter.upper(),
+            letter=p.letter.lower() if p.blank else p.letter.upper(),
         )
         db.add(tile)
     player = db.get(models.GamePlayer, req.player_id)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -80,6 +80,25 @@ def test_game_lifecycle() -> None:
     assert len(state.tiles) == 3
 
 
+def test_blank_tile_scores_zero() -> None:
+    game_id, p1, _p2, rack1 = _setup_game()
+    # ensure player has a blank
+    with SessionLocal() as db:
+        player = db.query(models.GamePlayer).filter_by(id=p1).one()
+        player.rack = "?" + player.rack[1:]
+        db.commit()
+    placements = [
+        {"row": 7, "col": 7, "letter": "H", "blank": True},
+        {"row": 7, "col": 8, "letter": "O", "blank": False},
+        {"row": 7, "col": 9, "letter": "U", "blank": False},
+    ]
+    with SessionLocal() as db:
+        score = play_move(game_id, MoveRequest(player_id=p1, placements=placements), db=db)[
+            "score"
+        ]
+    assert score == 4
+
+
 def test_exchange_pass_resign() -> None:
     game_id, p1, p2, rack1 = _setup_game()
     letter = rack1[0]

--- a/frontend/components/Game.vue
+++ b/frontend/components/Game.vue
@@ -18,9 +18,8 @@
 
     <div class="validation">
       <div class="score">
-        Score <br>
-        Toi : {{ score }} <br>
-        Adversaire : {{ score_adversaire }}
+        Toi {{ score }} <br>
+        Adversaire {{ score_adversaire }}
       </div>
 
       <button @click="$emit('clear')">
@@ -29,15 +28,15 @@
       </button>
       <button @click="$emit('shuffle')">
         <!-- icône -->
-        Échanger
+        Mélanger
       </button>
-      <button @click="$emit('pass')">
+      <button v-if="tile" @click="$emit('play')">
+        <!-- icône -->
+        Jouer
+      </button>
+      <button v-if="!tile" @click="$emit('pass')">
         <!-- icône -->
         Passer
-      </button>
-      <button @click="$emit('play')">
-        <!-- icône -->
-        Valider le coup
       </button>
     </div>
   </div>

--- a/frontend/components/Grid.vue
+++ b/frontend/components/Grid.vue
@@ -5,8 +5,8 @@
         @dragover.prevent @drop="onDrop($event, rowIndex, colIndex)" @click="remove(rowIndex, colIndex)"
         :draggable="!!cell" @dragstart="onDragStart($event, rowIndex, colIndex)">
         <template v-if="cell">
-          <span class="letter">{{ cell }}</span>
-          <span class="points">{{ letterPoints[cell] }}</span>
+          <span class="letter">{{ cell.toUpperCase() }}</span>
+          <span class="points">{{ cell === cell.toLowerCase() ? 0 : letterPoints[cell.toUpperCase()] }}</span>
         </template>
         <template v-else>
           {{ label(board[rowIndex][colIndex]) }}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -196,33 +196,52 @@
             if (!letter) return
             const placementIdx = placements.value.findIndex(p => p.row === data.row && p.col === data.col)
             if (placementIdx !== -1) placements.value.splice(placementIdx, 1)
-            rack.value.splice(idx, 0, letter)
+            rack.value.splice(idx, 0, letter === letter.toLowerCase() ? '?' : letter)
           }
         }
 
         function placed(payload) {
           rack.value.splice(payload.index, 1)
-          placements.value.push({ row: payload.row, col: payload.col, letter: payload.letter })
+          if (payload.letter === '?') {
+            const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+            let choice = prompt(`Choisissez une lettre pour le joker:\n${letters}`)
+            if (!choice) {
+              rack.value.splice(payload.index, 0, '?')
+              gameRef.value.gridRef.value.takeBack(payload.row, payload.col)
+              return
+            }
+            choice = choice.toUpperCase()
+            if (!letters.includes(choice)) {
+              rack.value.splice(payload.index, 0, '?')
+              gameRef.value.gridRef.value.takeBack(payload.row, payload.col)
+              return
+            }
+            gameRef.value.setTile(payload.row, payload.col, choice.toLowerCase())
+            placements.value.push({ row: payload.row, col: payload.col, letter: choice, blank: true })
+          } else {
+            placements.value.push({ row: payload.row, col: payload.col, letter: payload.letter, blank: false })
+          }
         }
 
         function removed(payload) {
           const { row, col, letter } = payload
           const i = placements.value.findIndex(p => p.row === row && p.col === col)
           if (i !== -1) placements.value.splice(i, 1)
-          rack.value.push(letter)
+          rack.value.push(letter === letter.toLowerCase() ? '?' : letter)
         }
 
         function moved(payload) {
-          const { fromRow, fromCol, toRow, toCol, letter } = payload
+          const { fromRow, fromCol, toRow, toCol } = payload
           const i = placements.value.findIndex(p => p.row === fromRow && p.col === fromCol)
           if (i !== -1) {
-            placements.value[i] = { row: toRow, col: toCol, letter }
+            placements.value[i].row = toRow
+            placements.value[i].col = toCol
           }
         }
 
         function clearMove() {
           gameRef.value.clearAll(placements.value)
-          placements.value.forEach(p => rack.value.push(p.letter))
+          placements.value.forEach(p => rack.value.push(p.blank ? '?' : p.letter))
           placements.value = []
         }
 
@@ -255,8 +274,8 @@
           result.value = `Score : ${data.score}`
           placements.value = []
           if (data.bot_move) {
-            data.bot_move.forEach(([row, col, letter]) => {
-              gameRef.value.setTile(row, col, letter)
+            data.bot_move.forEach(([row, col, letter, blank]) => {
+              gameRef.value.setTile(row, col, blank ? letter.toLowerCase() : letter)
             })
           }
           const stateRes = await fetch(


### PR DESCRIPTION
## Summary
- Prompt players to choose a replacement letter when playing a `?` tile and display it with 0 points
- Treat lowercase tiles as blanks in scoring and persist blank tiles in the database
- Add regression test ensuring blank tiles score zero

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6898a47ab1b88327b818abd5fba8111e