### PR TITLE
Improve responsive design for Scrabble board

### DIFF
--- a/frontend/components/Grid.vue
+++ b/frontend/components/Grid.vue
@@ -1,16 +1,19 @@
 <template>
-  <div class="scrabble-grid">
-    <div v-for="(row, rowIndex) in grid" :key="rowIndex" class="row">
-      <div v-for="(cell, colIndex) in row" :key="colIndex" class="cell" :class="board[rowIndex][colIndex]"
-        @dragover.prevent @drop="onDrop($event, rowIndex, colIndex)" @click="remove(rowIndex, colIndex)"
-        :draggable="!!cell" @dragstart="onDragStart($event, rowIndex, colIndex)">
-        <template v-if="cell">
-          <span class="letter">{{ cell.toUpperCase() }}</span>
-          <span class="points">{{ cell === cell.toLowerCase() ? 0 : letterPoints[cell.toUpperCase()] }}</span>
-        </template>
-        <template v-else>
-          {{ label(board[rowIndex][colIndex]) }}
-        </template>
+  <div class="scrabble-grid-container">
+    <div class="scrabble-grid">
+      <div v-for="(row, rowIndex) in grid" :key="rowIndex" class="row">
+        <div v-for="(cell, colIndex) in row" :key="colIndex" class="cell"
+          :class="[board[rowIndex][colIndex], { 'has-letter': !!cell }]" @dragover.prevent
+          @drop="onDrop($event, rowIndex, colIndex)" @click="remove(rowIndex, colIndex)" :draggable="!!cell"
+          @dragstart="onDragStart($event, rowIndex, colIndex)">
+          <template v-if="cell">
+            <span class="letter">{{ cell.toUpperCase() }}</span>
+            <span class="points">{{ cell === cell.toLowerCase() ? 0 : letterPoints[cell.toUpperCase()] }}</span>
+          </template>
+          <template v-else>
+            <span class="label">{{ label(board[rowIndex][colIndex]) }}</span>
+          </template>
+        </div>
       </div>
     </div>
   </div>
@@ -39,7 +42,14 @@ boardRef.value[7][7] = 'CENTER'
 const grid = ref(Array.from({ length: size }, () => Array(size).fill('')))
 
 function label(type) {
-  switch (type) { case 'TW': return 'TW'; case 'DW': return 'DW'; case 'TL': return 'TL'; case 'DL': return 'DL'; case 'CENTER': return '★'; default: return '' }
+  switch (type) {
+    case 'TW': return 'TW'
+    case 'DW': return 'DW'
+    case 'TL': return 'TL'
+    case 'DL': return 'DL'
+    case 'CENTER': return '★'
+    default: return ''
+  }
 }
 
 function onDrop(e, row, col) {
@@ -102,60 +112,284 @@ defineExpose({ clearAll, takeBack, setTile })
 </script>
 
 <style scoped>
-  .scrabble-grid {
-    display: grid;
-    grid-template-rows: repeat(15, var(--cell-size));
-    grid-template-columns: repeat(15, var(--cell-size));
-    border: 1px solid #ccc;
-  }
-
-.row {
-  display: contents
+/* Variables CSS pour les dimensions */
+:root {
+  --cell-size: clamp(20px, 4.5vw, 32px);
+  --grid-gap: 0;
+  --grid-border-width: clamp(1px, 0.2vw, 2px);
 }
 
-  .cell {
-    width: var(--cell-size);
-    height: var(--cell-size);
-    border: 1px solid #ccc;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-weight: bold;
-    user-select: none;
-    position: relative;
-  }
+/* Conteneur principal de la grille */
+.scrabble-grid-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-md, 1rem);
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: var(--radius-lg, 16px);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.03);
+  margin: var(--spacing-lg, 1.5rem) auto;
+  width: fit-content;
+  max-width: 100%;
+}
+
+/* Grille 15x15 */
+.scrabble-grid {
+  display: grid;
+  grid-template-rows: repeat(15, var(--cell-size));
+  grid-template-columns: repeat(15, var(--cell-size));
+  gap: var(--grid-gap);
+  background: #999;
+  border: var(--grid-border-width) solid #666;
+  border-radius: var(--radius-sm, 8px);
+  padding: var(--grid-gap);
+  width: fit-content;
+  aspect-ratio: 1;
+}
+
+/* Lignes (pour compatibilité) */
+.row {
+  display: contents;
+}
+
+/* Cases individuelles */
+.cell {
+  width: var(--cell-size);
+  height: var(--cell-size);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  user-select: none;
+  position: relative;
+  border-radius: 2px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  background: #f5f5dc;
+  color: #333;
+  font-size: clamp(8px, 1.8vw, 12px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* États de hover et active */
+.cell:hover {
+  transform: scale(1.05);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+}
+
+.cell:active {
+  transform: scale(0.95);
+}
+
+/* Lettres et points */
+.letter {
+  font-weight: 700;
+  font-size: clamp(10px, 2.2vw, 16px);
+  color: #333;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
+}
 
 .points {
   position: absolute;
-  bottom: 2px;
-  right: 2px;
-  font-size: .6rem;
-  font-weight: normal
+  bottom: clamp(1px, 0.3vw, 3px);
+  right: clamp(1px, 0.3vw, 3px);
+  font-size: clamp(5px, 1vw, 8px);
+  font-weight: 600;
+  color: #555;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  width: clamp(8px, 1.8vw, 12px);
+  height: clamp(8px, 1.8vw, 12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
+/* Labels des cases spéciales */
+.label {
+  font-size: clamp(6px, 1.4vw, 10px);
+  font-weight: 700;
+  text-align: center;
+  line-height: 1;
+}
+
+/* Cases spéciales - Couleurs originales */
 .TW {
   background: linear-gradient(to bottom right, #CB514E, #A94442);
-  color: #fff
+  color: #fff;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.2);
 }
 
-.DW,
+.DW {
+  background: linear-gradient(to bottom right, #C18AB3, #9C6F9E);
+  color: #fff;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.2);
+}
+
 .CENTER {
   background: linear-gradient(to bottom right, #C18AB3, #9C6F9E);
-  color: #fff
+  color: #fff;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.2);
 }
 
 .TL {
   background: linear-gradient(to bottom right, #87B5D2, #5C8EAB);
-  color: #fff
+  color: #fff;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.2);
 }
 
 .DL {
   background: linear-gradient(to bottom right, #90caf9, #5a9bdc);
-  color: #fff
+  color: #fff;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.2);
 }
 
+/* Cases avec lettres posées */
 .use {
-  background: linear-gradient(to bottom right, #EBBF56, #D6A63B);
-  color: #000
+  background: linear-gradient(to bottom right, #EBBF56, #D6A63B) !important;
+  color: #000 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15), inset 0 1px 2px rgba(255, 255, 255, 0.5) !important;
+  border: 2px solid rgba(255, 255, 255, 0.8) !important;
+}
+
+.has-letter {
+  cursor: grab;
+}
+
+.has-letter:active {
+  cursor: grabbing;
+}
+
+/* Responsive pour tablettes */
+@media (max-width: 768px) {
+  :root {
+    --cell-size: clamp(18px, 5.5vw, 28px);
+    --grid-gap: 0;
+    --grid-border-width: 1px;
+  }
+
+  .scrabble-grid-container {
+    padding: var(--spacing-sm, 0.5rem);
+    margin: var(--spacing-md, 1rem) auto;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .scrabble-grid {
+    max-width: 100%;
+  }
+
+  .letter {
+    font-size: clamp(8px, 2vw, 14px);
+  }
+
+  .points {
+    bottom: 1px;
+    right: 1px;
+    font-size: clamp(4px, 0.8vw, 7px);
+    width: clamp(6px, 1.5vw, 10px);
+    height: clamp(6px, 1.5vw, 10px);
+  }
+
+  .label {
+    font-size: clamp(5px, 1.2vw, 8px);
+  }
+}
+
+/* Responsive pour mobiles - GRILLE 100% WIDTH SANS BORDURES */
+@media (max-width: 480px) {
+  :root {
+    --cell-size: calc((100vw - 1rem) / 15);
+    --grid-gap: 0;
+    --grid-border-width: 0px;
+  }
+
+  .scrabble-grid-container {
+    padding: 0;
+    margin: 0;
+    width: 100vw;
+    max-width: 100vw;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .scrabble-grid {
+    width: 100%;
+    max-width: 100%;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .cell {
+    border-radius: 1px;
+    border: 0.5px solid #ccc;
+  }
+
+  .letter {
+    font-size: clamp(7px, 1.8vw, 12px);
+  }
+
+  .points {
+    font-size: clamp(3px, 0.7vw, 6px);
+    width: clamp(5px, 1.2vw, 8px);
+    height: clamp(5px, 1.2vw, 8px);
+  }
+
+  .label {
+    font-size: clamp(4px, 1vw, 7px);
+  }
+}
+
+/* Amélioration des transitions */
+.cell {
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cell:hover {
+  transition-duration: 0.1s;
+}
+
+/* Effet de glissement lors du drag & drop */
+.cell[draggable="true"] {
+  cursor: grab;
+}
+
+.cell[draggable="true"]:active {
+  cursor: grabbing;
+  transform: scale(1.1) rotate(2deg);
+  z-index: 10;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+}
+
+/* Animation pour les nouvelles lettres posées */
+@keyframes letterPlace {
+  0% {
+    transform: scale(0) rotate(180deg);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(0deg);
+  }
+
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
+.has-letter .letter {
+  animation: letterPlace 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Effet de focus pour l'accessibilité */
+.cell:focus {
+  outline: 2px solid var(--color-title, #398df5);
+  outline-offset: 2px;
+  z-index: 2;
 }
 </style>

--- a/frontend/components/Grid.vue
+++ b/frontend/components/Grid.vue
@@ -102,26 +102,28 @@ defineExpose({ clearAll, takeBack, setTile })
 </script>
 
 <style scoped>
-.scrabble-grid {
-  display: grid;
-  grid-template-rows: repeat(15, 30px);
-  grid-template-columns: repeat(15, 30px);
-  border: 1px solid #ccc
-}
+  .scrabble-grid {
+    display: grid;
+    grid-template-rows: repeat(15, var(--cell-size));
+    grid-template-columns: repeat(15, var(--cell-size));
+    border: 1px solid #ccc;
+  }
 
 .row {
   display: contents
 }
 
-.cell {
-  border: 1px solid #ccc;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: bold;
-  user-select: none;
-  position: relative
-}
+  .cell {
+    width: var(--cell-size);
+    height: var(--cell-size);
+    border: 1px solid #ccc;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    user-select: none;
+    position: relative;
+  }
 
 .points {
   position: absolute;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -80,6 +80,8 @@
   --radius-md: 12px;
   --radius-lg: 16px;
   --radius-xl: 20px;
+  --tile-size: 35px;
+  --cell-size: 30px;
 }
 
 * {
@@ -265,8 +267,8 @@ button:active,
 
 /* Tuiles sans bordures, effet plus doux */
 .tile {
-  width: 35px;
-  height: 35px;
+  width: var(--tile-size);
+  height: var(--tile-size);
   background: var(--color-primary);
   border-radius: var(--radius-sm);
   display: flex;
@@ -417,6 +419,10 @@ li a:focus {
 
 /* Responsive amélioré */
 @media (max-width: 768px) {
+  :root {
+    --tile-size: 30px;
+    --cell-size: 24px;
+  }
   body {
     padding: var(--spacing-sm);
   }
@@ -456,8 +462,6 @@ li a:focus {
   }
 
   .tile {
-    width: 30px;
-    height: 30px;
     font-size: 0.8rem;
   }
 
@@ -480,6 +484,10 @@ li a:focus {
 
 /* Responsive pour très petits écrans */
 @media (max-width: 480px) {
+  :root {
+    --tile-size: 26px;
+    --cell-size: 20px;
+  }
   .validation {
     flex-direction: column;
     gap: var(--spacing-sm);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,4 +1,4 @@
-/* ===== PALETTE 1: JAUNE-BLEU ORIGINAL (ACTIVE) ===== 
+/* ===== PALETTE 1: JAUNE-BLEU ORIGINAL (ACTIVE) ===== */
 :root {
   --color-primary: linear-gradient(135deg, #F1D87A, #E6CC5A);
   --color-secondary: linear-gradient(135deg, #deb317, #B8961A);
@@ -12,6 +12,7 @@
 }
 
 /* ===== PALETTE 2: OCÉAN MODERNE ===== */
+/*
 :root {
   --color-primary: linear-gradient(135deg, #67e8f9, #06b6d4);
   --color-secondary: linear-gradient(135deg, #0891b2, #0e7490);
@@ -23,7 +24,7 @@
   --color-text-primary: #0f172a;
   --color-text-secondary: #475569;
 }
-
+*/
 
 /* ===== PALETTE 3: COUCHER DE SOLEIL =====
 :root {
@@ -80,8 +81,11 @@
   --radius-md: 12px;
   --radius-lg: 16px;
   --radius-xl: 20px;
-  --tile-size: 35px;
-  --cell-size: 30px;
+
+  /* Variables pour la grille Scrabble */
+  --cell-size: clamp(20px, 4.5vw, 32px);
+  --grid-gap: 0;
+  --grid-border-width: clamp(1px, 0.2vw, 2px);
 }
 
 * {
@@ -200,7 +204,8 @@ button:active,
   align-items: center;
   gap: var(--spacing-md);
   margin-top: var(--spacing-xl);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  /* Pas de retour à la ligne */
   padding: var(--spacing-md);
   background: rgba(255, 255, 255, 0.3);
   border-radius: var(--radius-lg);
@@ -215,8 +220,8 @@ button:active,
   box-shadow: 0 2px 8px var(--color-shadow);
   min-width: 120px;
   text-align: center;
-  order: -1;
-  /* Score toujours en premier */
+  flex-shrink: 0;
+  /* Ne se compresse pas */
 }
 
 .validation button {
@@ -241,17 +246,7 @@ button:active,
   max-width: 800px;
 }
 
-.scrabble-grid {
-  margin: var(--spacing-lg) auto;
-  padding: var(--spacing-md);
-  background: rgba(255, 255, 255, 0.5);
-  border-radius: var(--radius-lg);
-  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.03);
-  display: flex;
-  justify-content: center;
-  max-width: fit-content;
-}
-
+/* ===== RACK DES TUILES ===== */
 .rack {
   display: flex;
   gap: var(--spacing-sm);
@@ -261,14 +256,14 @@ button:active,
   border-radius: var(--radius-lg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
   margin: var(--spacing-lg) auto 0;
-  max-width: fit-content;
+  max-width: 100%;
   flex-wrap: wrap;
 }
 
 /* Tuiles sans bordures, effet plus doux */
 .tile {
-  width: var(--tile-size);
-  height: var(--tile-size);
+  width: 35px;
+  height: 35px;
   background: var(--color-primary);
   border-radius: var(--radius-sm);
   display: flex;
@@ -294,7 +289,7 @@ button:active,
   transform: rotate(5deg) scale(1.1);
 }
 
-.points {
+.tile .points {
   position: absolute;
   bottom: 2px;
   right: 3px;
@@ -417,12 +412,14 @@ li a:focus {
   justify-content: center;
 }
 
-/* Responsive amélioré */
+/* ===== RESPONSIVE ===== */
 @media (max-width: 768px) {
   :root {
-    --tile-size: 30px;
-    --cell-size: 24px;
+    --cell-size: clamp(18px, 5.5vw, 28px);
+    --grid-gap: 0;
+    --grid-border-width: 1px;
   }
+
   body {
     padding: var(--spacing-sm);
   }
@@ -443,10 +440,36 @@ li a:focus {
     padding: var(--spacing-md);
   }
 
-  /* La validation reste en ligne même sur mobile */
+  /* Grille 100% width sur mobile */
+  .scrabble-grid-container {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  /* Rack responsive */
+  .rack {
+    padding: var(--spacing-md);
+    gap: var(--spacing-xs);
+    margin: var(--spacing-md) auto 0;
+  }
+
+  .tile {
+    width: clamp(25px, 8vw, 35px);
+    height: clamp(25px, 8vw, 35px);
+    font-size: clamp(0.7rem, 2.5vw, 0.9rem);
+  }
+
+  .tile .points {
+    width: clamp(8px, 2.5vw, 12px);
+    height: clamp(8px, 2.5vw, 12px);
+    font-size: clamp(0.4rem, 1.5vw, 0.6rem);
+  }
+
+  /* Validation reste en ligne sur tablette */
   .validation {
     gap: var(--spacing-sm);
     padding: var(--spacing-sm);
+    flex-wrap: nowrap;
   }
 
   .validation .score {
@@ -460,52 +483,85 @@ li a:focus {
     padding: var(--spacing-sm) var(--spacing-md);
     font-size: 0.8rem;
   }
-
-  .tile {
-    font-size: 0.8rem;
-  }
-
-  .points {
-    width: 10px;
-    height: 10px;
-    font-size: 0.5rem;
-  }
-
-  .rack {
-    padding: var(--spacing-md);
-    gap: var(--spacing-xs);
-  }
-
-  .scrabble-grid {
-    margin: var(--spacing-md) auto;
-    padding: var(--spacing-sm);
-  }
 }
 
-/* Responsive pour très petits écrans */
+/* Responsive pour mobiles - GRILLE 100% WIDTH + BOUTONS EN LIGNE */
 @media (max-width: 480px) {
   :root {
-    --tile-size: 26px;
-    --cell-size: 20px;
+    --cell-size: calc((100vw - 1rem) / 15);
+    /* Grille prend vraiment toute la largeur */
+    --grid-gap: 0;
+    --grid-border-width: 0px;
   }
-  .validation {
-    flex-direction: column;
+
+  body {
+    padding: 0;
+  }
+
+  #app {
     gap: var(--spacing-sm);
+    padding: 0;
+    margin: 0;
+  }
+
+  .game {
+    border-radius: 0;
+    padding: var(--spacing-sm);
+    margin: 0;
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  /* Grille 100% width sur téléphone - SANS BORDURES */
+  .scrabble-grid-container {
+    width: 100vw;
+    max-width: 100vw;
+    padding: 0;
+    margin: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .tile {
+    width: clamp(20px, 6vw, 28px);
+    height: clamp(20px, 6vw, 28px);
+    font-size: clamp(0.6rem, 1.8vw, 0.8rem);
+  }
+
+  /* VALIDATION - TOUT SUR UNE LIGNE */
+  .validation {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs);
+    margin: var(--spacing-sm) 0;
+    justify-content: space-between;
   }
 
   .validation .score {
-    order: 0;
-    width: 100%;
+    min-width: 60px;
+    padding: var(--spacing-xs);
+    font-size: 0.7rem;
+    flex-shrink: 0;
   }
 
   .validation button {
+    min-width: 50px;
+    padding: var(--spacing-xs);
+    font-size: 0.6rem;
     flex: 1;
-    min-width: unset;
+  }
+
+  .rack {
+    margin: var(--spacing-sm) 0;
+    padding: var(--spacing-sm);
   }
 
   .nav {
     flex-direction: column;
     align-items: center;
+    padding: 0 var(--spacing-sm);
   }
 
   button,
@@ -533,9 +589,63 @@ li a:focus {
   animation: fadeIn 0.6s ease-out;
 }
 
+/* Animation pour les nouvelles lettres posées */
+@keyframes letterPlace {
+  0% {
+    transform: scale(0) rotate(180deg);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(0deg);
+  }
+
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
 /* Focus pour l'accessibilité */
 button:focus,
 .nav a:focus {
   outline: 2px solid var(--color-title);
   outline-offset: 2px;
+}
+
+/* Classes utilitaires */
+.text-center {
+  text-align: center;
+}
+
+.mt-auto {
+  margin-top: auto;
+}
+
+.mb-auto {
+  margin-bottom: auto;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Responsive helpers */
+.hidden-mobile {
+  display: block;
+}
+
+.hidden-desktop {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .hidden-mobile {
+    display: none;
+  }
+
+  .hidden-desktop {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- make grid tiles and board responsive using CSS variables
- adjust styles for tablet and mobile breakpoints

## Testing
- `make test` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6898c73f6a2883278a176ba5d4371a84