### PR TITLE
chore: add vitest setup and sample grid tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "scrabble",
+  "version": "1.0.0",
+  "description": "This project provides a minimal Scrabble setup:",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.41.1",
+    "@testing-library/vue": "^7.0.0",
+    "@vitejs/plugin-vue": "^4.3.1",
+    "@vitest/ui": "^0.34.4",
+    "@vue/test-utils": "^2.4.1",
+    "jsdom": "^22.1.0",
+    "msw": "^1.2.1",
+    "vitest": "^0.34.4"
+  }
+}

--- a/tests/Grid.spec.ts
+++ b/tests/Grid.spec.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils'
+import Grid from '@/components/Grid.vue'
+
+describe('Grid.vue', () => {
+  const letterPoints = { A: 1 }
+
+  it('renders 15x15 grid and center bonus', () => {
+    const wrapper = mount(Grid, { props: { letterPoints } })
+    expect(wrapper.findAll('.cell').length).toBe(225)
+    expect(wrapper.find('.CENTER').exists()).toBe(true)
+  })
+
+  it('emits placed and removed events', async () => {
+    const wrapper = mount(Grid, { props: { letterPoints } })
+    const cell = wrapper.find('.cell')
+    const dataTransfer = {
+      getData: () => JSON.stringify({ source: 'rack', index: 0, letter: 'A' })
+    }
+    await cell.trigger('drop', { dataTransfer })
+    expect(wrapper.emitted('placed')).toBeTruthy()
+    await cell.trigger('click')
+    expect(wrapper.emitted('removed')).toBeTruthy()
+  })
+})

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -1,0 +1,7 @@
+import { rest } from 'msw'
+
+export const handlers = [
+  rest.post('/games', (_req, res, ctx) => res(ctx.json({ game_id: 'g1' }))),
+  rest.post('/games/g1/join', (_req, res, ctx) => res(ctx.json({ player_id: 'p1' }))),
+  rest.post('/games/g1/start', (_req, res, ctx) => res(ctx.json({ ok: true }))),
+]

--- a/tests/msw/server.ts
+++ b/tests/msw/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,6 @@
+import { server } from './msw/server'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './frontend')
+    }
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setupTests.ts'],
+    globals: true,
+    coverage: { reporter: ['text', 'lcov'] }
+  }
+})


### PR DESCRIPTION
## Summary
- configure Vitest with Vue plugin and jsdom
- add MSW server for mocking API requests
- create sample unit tests for Grid component

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f2bd974883279e78c0ab5f010645