### PR TITLE
Toggle play/pass buttons based on tile placement

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -35,6 +35,7 @@
 
 - [x] Placement des lettres
 - [x] Calcul des scores
+- [ ] Gestion du niveau de l'IA (très facile : < 15pts, facile : < 20pts, moyen : < 25pts, difficile : < 30pts, hardcore : > 100pts)
 - [ ] Fin de partie, sauvegarde
 - [ ] Historique des parties (rejouer, consulter, supprimer)
 

--- a/frontend/components/Game.vue
+++ b/frontend/components/Game.vue
@@ -69,7 +69,7 @@ function handleRemoved(payload) {
 // ✅ Expose des wrappers stables
 function setTile(r, c, l, lock = true) {
   gridRef.value?.setTile(r, c, l, lock)
-  placements.value++
+  if (!lock) placements.value++
 }
 
 function takeBack(r, c) {
@@ -83,7 +83,10 @@ function clearAll(tiles) {
   placements.value = Math.max(0, placements.value - (tiles?.length || placements.value))
 }
 
-function lockTiles(tiles) { gridRef.value?.lockTiles(tiles) }
+function lockTiles(tiles) {
+  gridRef.value?.lockTiles(tiles)
+  placements.value = Math.max(0, placements.value - (tiles?.length || placements.value))
+}
 
 defineExpose({ gridRef, setTile, takeBack, clearAll, lockTiles })
 </script>

--- a/frontend/components/Game.vue
+++ b/frontend/components/Game.vue
@@ -5,8 +5,8 @@
       <button @click="$emit('finish')">Terminer la partie</button>
     </div>
 
-    <Grid ref="gridRef" :letter-points="letterPoints" @placed="$emit('placed', $event)"
-      @removed="$emit('removed', $event)" @moved="$emit('moved', $event)" />
+    <Grid ref="gridRef" :letter-points="letterPoints" @placed="handlePlaced"
+      @removed="handleRemoved" @moved="emit('moved', $event)" />
 
     <div class="rack" @dragover.prevent @drop="$emit('rack-drop', $event, rack.length)">
       <div v-for="(letter, idx) in rack" :key="idx" class="tile" draggable="true"
@@ -27,17 +27,17 @@
       <button @click="$emit('shuffle')">
         Mélanger
       </button>
-      <button v-if="tile" @click="$emit('play')">
+      <button v-show="placements" @click="$emit('play')">
         Jouer
       </button>
-      <button v-if="!tile" @click="$emit('pass')">
+      <button v-show="!placements" @click="$emit('pass')">
         Passer
       </button>
     </div>
   </div>
 </template>
 <script setup>
-import { defineExpose, ref } from 'vue'
+import { ref } from 'vue'
 import Grid from './Grid.vue'
 
 defineProps({
@@ -48,18 +48,42 @@ defineProps({
   score_adversaire: { type: Number, default: 0 }
 })
 
-defineEmits([
+const emit = defineEmits([
   'home', 'finish', 'placed', 'removed', 'moved',
   'rack-drop', 'drag-start', 'play', 'clear', 'shuffle', 'pass'
 ])
 
 const gridRef = ref(null)
+const placements = ref(0)
+
+function handlePlaced(payload) {
+  placements.value++
+  emit('placed', payload)
+}
+
+function handleRemoved(payload) {
+  if (placements.value > 0) placements.value--
+  emit('removed', payload)
+}
 
 // ✅ Expose des wrappers stables
-function setTile(r, c, l, lock = true) { gridRef.value?.setTile(r, c, l, lock) }
-function takeBack(r, c) { return gridRef.value?.takeBack(r, c) }
-function clearAll(placements) { gridRef.value?.clearAll(placements) }
-function lockTiles(placements) { gridRef.value?.lockTiles(placements) }
+function setTile(r, c, l, lock = true) {
+  gridRef.value?.setTile(r, c, l, lock)
+  placements.value++
+}
+
+function takeBack(r, c) {
+  const letter = gridRef.value?.takeBack(r, c)
+  if (letter) placements.value = Math.max(0, placements.value - 1)
+  return letter
+}
+
+function clearAll(tiles) {
+  gridRef.value?.clearAll(tiles)
+  placements.value = Math.max(0, placements.value - (tiles?.length || placements.value))
+}
+
+function lockTiles(tiles) { gridRef.value?.lockTiles(tiles) }
 
 defineExpose({ gridRef, setTile, takeBack, clearAll, lockTiles })
 </script>

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -35,10 +35,20 @@ describe('Game.vue', () => {
         expect(w.emitted('pass')).toBeTruthy()
     })
 
-    it('1 tile on game', async () => {
-        const w = mount(Game, { props: { rack: ['A'], letterPoints: { A: 1 } } })
+    it('existing locked tile still shows Passer', async () => {
+        const w = mount(Game, { props: { rack: [], letterPoints: { A: 1 } } })
             ; (w.vm as any).setTile(7, 7, 'A', true)
+        await nextTick()
+        const jouerBtn = w.findAll('button').find(b => b.text().trim() === 'Jouer')
+        expect(jouerBtn?.element.style.display).toBe('none')
+        await getByText(w, 'button', 'Passer').trigger('click')
+        expect(w.emitted('pass')).toBeTruthy()
+    })
 
+    it('placing a new tile shows Jouer', async () => {
+        const w = mount(Game, { props: { rack: ['A'], letterPoints: { A: 1 } } })
+        w.findComponent({ name: 'Grid' }).vm.$emit('placed', { row: 7, col: 7, letter: 'A' })
+        await nextTick()
         await getByText(w, 'button', 'Jouer').trigger('click')
         expect(w.emitted('play')).toBeTruthy()
     })


### PR DESCRIPTION
## Summary
- track placed tiles in Game component
- toggle between **Jouer** and **Passer** buttons based on tile placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a371325d48327953ec4bb33b91f4e