### PR TITLE
feat: allow users to choose color palette

### DIFF
--- a/alembic/versions/1c369d8b6f2e_add_color_palette.py
+++ b/alembic/versions/1c369d8b6f2e_add_color_palette.py
@@ -1,0 +1,23 @@
+"""add color palette to users
+
+Revision ID: 1c369d8b6f2e
+Revises: f249aee58340
+Create Date: 2025-09-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1c369d8b6f2e'
+down_revision = 'f249aee58340'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('color_palette', sa.String(length=20), nullable=False, server_default='palette1'))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'color_palette')

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -295,6 +295,13 @@ class LoginRequest(AuthRequest):
 class UserResponse(BaseModel):
     user_id: int
     email: str  # on renvoie username comme 'email' par compatibilité
+    display_name: str | None = None
+    avatar_url: str | None = None
+    color_palette: str | None = None
+
+
+class PaletteUpdate(BaseModel):
+    palette: str
 
 
 class UserManager:
@@ -447,7 +454,19 @@ def me_endpoint(request: Request, db: Session = Depends(get_db)) -> UserResponse
         email=user.username,
         display_name=user.display_name,
         avatar_url=user.avatar_url,
+        color_palette=user.color_palette,
     )
+
+
+@router.post("/auth/me/palette")
+def update_palette(
+    req: PaletteUpdate, request: Request, db: Session = Depends(get_db)
+) -> dict[str, str]:
+    user = get_current_user(request, db)
+    user.color_palette = req.palette
+    db.add(user)
+    db.commit()
+    return {"color_palette": user.color_palette}
 
 # Backward compatible alias for tests expecting `me`
 me = me_lookup

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -32,6 +32,9 @@ class User(TimestampMixin, Base):
     deletion_locked_until: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True)
     )
+    color_palette: Mapped[str] = mapped_column(
+        String(20), default="palette1", nullable=False
+    )
 
     oauth_accounts: Mapped[List[OAuthAccount]] = relationship(
         "OAuthAccount", cascade="all, delete-orphan", back_populates="user"

--- a/backend/tests/user/test_auth.py
+++ b/backend/tests/user/test_auth.py
@@ -37,6 +37,15 @@ def test_auth_flow() -> None:
     r = client.get("/auth/me")
     assert r.status_code == 200
     assert r.json()["email"] == email
+    assert r.json()["color_palette"] == "palette1"
+
+    # Update palette
+    r = client.post("/auth/me/palette", json={"palette": "palette2"})
+    assert r.status_code == 200
+    assert r.json()["color_palette"] == "palette2"
+    r = client.get("/auth/me")
+    assert r.status_code == 200
+    assert r.json()["color_palette"] == "palette2"
 
     # Logout -> 200 + cookies supprimés
     r = client.post("/auth/logout")

--- a/frontend/components/Profile.vue
+++ b/frontend/components/Profile.vue
@@ -22,6 +22,10 @@
             <span class="info-label">Avatar</span>
             <span class="info-value">{{ user.avatar_url || 'Aucun' }}</span>
           </div>
+          <div class="info-item">
+            <span class="info-label">Palette</span>
+            <span class="info-value">{{ user.color_palette }}</span>
+          </div>
         </div>
       </div>
 
@@ -81,6 +85,7 @@ onMounted(async () => {
     const res = await fetch('http://localhost:8000/auth/me', { credentials: 'include' })
     if (res.ok) {
       user.value = await res.json()
+      document.documentElement.setAttribute('data-theme', user.value.color_palette || 'palette1')
       const res2 = await fetch('http://localhost:8000/games/user/' + user.value.user_id, { credentials: 'include' })
       Object.assign(user.value, await res2.json())
     }

--- a/frontend/components/Profile.vue
+++ b/frontend/components/Profile.vue
@@ -22,9 +22,24 @@
             <span class="info-label">Avatar</span>
             <span class="info-value">{{ user.avatar_url || 'Aucun' }}</span>
           </div>
-          <div class="info-item">
+          <div class="info-item palette-picker">
             <span class="info-label">Palette</span>
-            <span class="info-value">{{ user.color_palette }}</span>
+            <div class="palette-options">
+              <div
+                v-for="p in palettes"
+                :key="p.name"
+                class="palette-option"
+                :class="{ active: selected === p.name }"
+                @click="selectPalette(p.name)"
+              >
+                <span
+                  v-for="c in p.colors"
+                  :key="c"
+                  class="swatch"
+                  :style="{ background: c }"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -79,13 +94,22 @@ import { onMounted, ref } from 'vue'
 
 const emit = defineEmits(['back', 'logout'])
 const user = ref(null)
+const palettes = [
+  { name: 'palette1', colors: ['#F1D87A', '#398df5'] },
+  { name: 'palette2', colors: ['#67e8f9', '#f59e0b'] },
+  { name: 'palette3', colors: ['#fbbf24', '#7c3aed'] },
+  { name: 'palette4', colors: ['#84cc16', '#2563eb'] },
+  { name: 'palette5', colors: ['#a78bfa', '#f59e0b'] }
+]
+const selected = ref('palette1')
 
 onMounted(async () => {
   try {
     const res = await fetch('http://localhost:8000/auth/me', { credentials: 'include' })
     if (res.ok) {
       user.value = await res.json()
-      document.documentElement.setAttribute('data-theme', user.value.color_palette || 'palette1')
+      selected.value = user.value.color_palette || 'palette1'
+      document.documentElement.setAttribute('data-theme', selected.value)
       const res2 = await fetch('http://localhost:8000/games/user/' + user.value.user_id, { credentials: 'include' })
       Object.assign(user.value, await res2.json())
     }
@@ -93,6 +117,26 @@ onMounted(async () => {
     console.error('Erreur lors du chargement du profil:', err)
   }
 })
+
+function selectPalette(palette) {
+  selected.value = palette
+  updatePalette()
+}
+
+async function updatePalette() {
+  document.documentElement.setAttribute('data-theme', selected.value)
+  try {
+    await fetch('http://localhost:8000/auth/me/palette', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ palette: selected.value })
+    })
+    if (user.value) user.value.color_palette = selected.value
+  } catch (err) {
+    console.error('Erreur mise à jour palette:', err)
+  }
+}
 
 async function deleteAccount() {
   if (!confirm('Êtes-vous sûr de vouloir supprimer votre compte ?')) {
@@ -229,6 +273,32 @@ async function deleteAccount() {
   color: var(--color-text-primary);
   font-size: 1rem;
   word-break: break-all;
+}
+
+.palette-options {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.palette-option {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.palette-option.active {
+  border-color: var(--color-title);
+}
+
+.swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-xs);
 }
 
 .stats-grid {

--- a/frontend/components/Settings.vue
+++ b/frontend/components/Settings.vue
@@ -1,11 +1,61 @@
 <template>
   <div class="settings">
     <h1>Paramètres</h1>
+    <div class="palette-section">
+      <label for="palette">Palette de couleurs</label>
+      <select id="palette" v-model="selected" @change="updatePalette">
+        <option v-for="p in palettes" :key="p" :value="p">{{ p }}</option>
+      </select>
+    </div>
     <button @click="$emit('back')">Retour</button>
   </div>
 </template>
 
 <script setup>
-defineEmits(['back'])
+import { ref, onMounted } from 'vue'
+
+const emit = defineEmits(['back'])
+const palettes = ['palette1', 'palette2', 'palette3', 'palette4', 'palette5']
+const selected = ref('palette1')
+
+onMounted(async () => {
+  try {
+    const res = await fetch('http://localhost:8000/auth/me', { credentials: 'include' })
+    if (res.ok) {
+      const data = await res.json()
+      selected.value = data.color_palette || 'palette1'
+      document.documentElement.setAttribute('data-theme', selected.value)
+    }
+  } catch (err) {
+    console.error('Erreur chargement palette:', err)
+  }
+})
+
+async function updatePalette() {
+  document.documentElement.setAttribute('data-theme', selected.value)
+  try {
+    await fetch('http://localhost:8000/auth/me/palette', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ palette: selected.value })
+    })
+  } catch (err) {
+    console.error('Erreur mise à jour palette:', err)
+  }
+}
 </script>
 
+<style scoped>
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  align-items: center;
+}
+.palette-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+</style>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,5 +1,6 @@
-/* ===== PALETTE 1: JAUNE-BLEU ORIGINAL (ACTIVE) ===== */
-:root {
+/* ===== PALETTE 1: JAUNE-BLEU ORIGINAL ===== */
+:root,
+:root[data-theme='palette1'] {
   --color-primary: linear-gradient(135deg, #F1D87A, #E6CC5A);
   --color-secondary: linear-gradient(135deg, #deb317, #B8961A);
   --color-title: #398df5;
@@ -12,8 +13,7 @@
 }
 
 /* ===== PALETTE 2: OCÉAN MODERNE ===== */
-/*
-:root {
+:root[data-theme='palette2'] {
   --color-primary: linear-gradient(135deg, #67e8f9, #06b6d4);
   --color-secondary: linear-gradient(135deg, #0891b2, #0e7490);
   --color-title: #f59e0b;
@@ -24,10 +24,9 @@
   --color-text-primary: #0f172a;
   --color-text-secondary: #475569;
 }
-*/
 
-/* ===== PALETTE 3: COUCHER DE SOLEIL =====
-:root {
+/* ===== PALETTE 3: COUCHER DE SOLEIL ===== */
+:root[data-theme='palette3'] {
   --color-primary: linear-gradient(135deg, #fbbf24, #f59e0b);
   --color-secondary: linear-gradient(135deg, #ea580c, #dc2626);
   --color-title: #7c3aed;
@@ -38,10 +37,9 @@
   --color-text-primary: #1f2937;
   --color-text-secondary: #6b7280;
 }
-*/
 
-/* ===== PALETTE 4: NATURE FRAÎCHE =====
-:root {
+/* ===== PALETTE 4: NATURE FRAÎCHE ===== */
+:root[data-theme='palette4'] {
   --color-primary: linear-gradient(135deg, #84cc16, #65a30d);
   --color-secondary: linear-gradient(135deg, #059669, #047857);
   --color-title: #2563eb;
@@ -52,10 +50,9 @@
   --color-text-primary: #14532d;
   --color-text-secondary: #4b5563;
 }
-*/
 
-/* ===== PALETTE 5: LAVANDE MODERNE =====
-:root {
+/* ===== PALETTE 5: LAVANDE MODERNE ===== */
+:root[data-theme='palette5'] {
   --color-primary: linear-gradient(135deg, #a78bfa, #8b5cf6);
   --color-secondary: linear-gradient(135deg, #6366f1, #4f46e5);
   --color-title: #f59e0b;
@@ -66,7 +63,6 @@
   --color-text-primary: #581c87;
   --color-text-secondary: #6b7280;
 }
-*/
 
 /* Espacements et rayons */
 :root {


### PR DESCRIPTION
## Summary
- add `color_palette` field on users with migration and endpoint to update it
- expose palette selection in profile/settings and apply selected theme
- support multiple CSS palettes with `data-theme` switch

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca6b296d483279629ed57cf8e162b