### PR TITLE
feat: allow configurable backend URL

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';

--- a/frontend/authHeartbeat.js
+++ b/frontend/authHeartbeat.js
@@ -1,22 +1,24 @@
-let timer;
+import { API_BASE } from './api.js'
+
+let timer
 
 export function startAuthHeartbeat() {
-  stopAuthHeartbeat();
+  stopAuthHeartbeat()
   timer = setInterval(async () => {
     try {
-      await fetch('http://localhost:8000/auth/refresh', {
+      await fetch(`${API_BASE}/auth/refresh`, {
         method: 'POST',
         credentials: 'include'
-      });
+      })
     } catch {
       // ignore
     }
-  }, 12 * 60 * 1000);
+  }, 12 * 60 * 1000)
 }
 
 export function stopAuthHeartbeat() {
   if (timer) {
-    clearInterval(timer);
-    timer = undefined;
+    clearInterval(timer)
+    timer = undefined
   }
 }

--- a/frontend/components/Login.vue
+++ b/frontend/components/Login.vue
@@ -79,6 +79,7 @@
 
 <script setup>
 import { ref } from 'vue'
+import { API_BASE } from '../api.js'
 
 const emit = defineEmits(['auth'])
 
@@ -93,7 +94,7 @@ async function submit() {
   const endpoint = isRegister.value ? 'auth/register' : 'auth/login'
 
   try {
-    const res = await fetch(`http://localhost:8000/${endpoint}`, {
+    const res = await fetch(`${API_BASE}/${endpoint}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -123,7 +124,7 @@ function toggle() {
 }
 
 function loginGoogle() {
-  window.location.href = 'http://localhost:8000/auth/google/authorize'
+  window.location.href = `${API_BASE}/auth/google/authorize`
 }
 </script>
 

--- a/frontend/components/Profile.vue
+++ b/frontend/components/Profile.vue
@@ -108,6 +108,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
+import { API_BASE } from '../api.js'
 
 const emit = defineEmits(['back', 'logout'])
 const user = ref(null)
@@ -126,12 +127,12 @@ const defaultAvatars = Array.from(
 
 onMounted(async () => {
   try {
-    const res = await fetch('http://localhost:8000/auth/me', { credentials: 'include' })
+    const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
     if (res.ok) {
       user.value = await res.json()
       selected.value = user.value.color_palette || 'palette1'
       document.documentElement.setAttribute('data-theme', selected.value)
-      const res2 = await fetch('http://localhost:8000/games/user/' + user.value.user_id, { credentials: 'include' })
+      const res2 = await fetch(`${API_BASE}/games/user/${user.value.user_id}`, { credentials: 'include' })
       Object.assign(user.value, await res2.json())
     }
   } catch (err) {
@@ -150,7 +151,7 @@ async function onFileChange(e) {
   const form = new FormData()
   form.append('file', file)
   try {
-    const res = await fetch('http://localhost:8000/auth/me/avatar', {
+    const res = await fetch(`${API_BASE}/auth/me/avatar`, {
       method: 'POST',
       credentials: 'include',
       body: form
@@ -168,7 +169,7 @@ async function selectAvatar(url) {
   const form = new FormData()
   form.append('choice', url.split('/').pop())
   try {
-    const res = await fetch('http://localhost:8000/auth/me/avatar', {
+    const res = await fetch(`${API_BASE}/auth/me/avatar`, {
       method: 'POST',
       credentials: 'include',
       body: form
@@ -185,7 +186,7 @@ async function selectAvatar(url) {
 async function updatePalette() {
   document.documentElement.setAttribute('data-theme', selected.value)
   try {
-    await fetch('http://localhost:8000/auth/me/palette', {
+    await fetch(`${API_BASE}/auth/me/palette`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -203,7 +204,7 @@ async function deleteAccount() {
     return
   }
   try {
-    await fetch('http://localhost:8000/me/deletion-request', {
+    await fetch(`${API_BASE}/me/deletion-request`, {
       method: 'POST',
       credentials: 'include',
     })

--- a/frontend/components/Settings.vue
+++ b/frontend/components/Settings.vue
@@ -13,6 +13,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { API_BASE } from '../api.js'
 
 const emit = defineEmits(['back'])
 const palettes = ['palette1', 'palette2', 'palette3', 'palette4', 'palette5']
@@ -20,7 +21,7 @@ const selected = ref('palette1')
 
 onMounted(async () => {
   try {
-    const res = await fetch('http://localhost:8000/auth/me', { credentials: 'include' })
+    const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
     if (res.ok) {
       const data = await res.json()
       selected.value = data.color_palette || 'palette1'
@@ -34,7 +35,7 @@ onMounted(async () => {
 async function updatePalette() {
   document.documentElement.setAttribute('data-theme', selected.value)
   try {
-    await fetch('http://localhost:8000/auth/me/palette', {
+    await fetch(`${API_BASE}/auth/me/palette`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,8 +18,7 @@
     import { runBotThinking } from './botThinking.js'
     import { showInvalidWords } from './invalidWords.js'
     import { collectWords } from './validateWords.js'
-
-    const API_BASE = 'http://localhost:8000'
+    import { API_BASE } from './api.js'
 
     document.addEventListener('visibilitychange', async () => {
       if (document.visibilityState === 'visible') {
@@ -126,7 +125,7 @@
           try {
             const results = await Promise.all(
               words.map(w =>
-                fetch(`http://localhost:8000/validate?word=${encodeURIComponent(w)}`)
+                fetch(`${API_BASE}/validate?word=${encodeURIComponent(w)}`)
                   .then(r => r.json())
                   .then(d => d.valid)
               )
@@ -141,7 +140,7 @@
 
         async function loadGames() {
           if (!userId.value) return
-          const res = await fetch(`http://localhost:8000/games?user_id=${userId.value}`)
+          const res = await fetch(`${API_BASE}/games?user_id=${userId.value}`)
           const data = await res.json()
           ongoingGames.value = data.ongoing
           finishedGames.value = data.finished
@@ -192,24 +191,24 @@
         }
 
         async function newGameBot() {
-          const resGame = await fetch('http://localhost:8000/games', {
+          const resGame = await fetch(`${API_BASE}/games`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ vs_computer: true })
           })
           const { game_id } = await resGame.json()
-          const joinRes = await fetch(`http://localhost:8000/games/${game_id}/join`, {
+          const joinRes = await fetch(`${API_BASE}/games/${game_id}/join`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ user_id: Number(userId.value) })
           })
           const { player_id } = await joinRes.json()
-          await fetch(`http://localhost:8000/games/${game_id}/join`, {
+          await fetch(`${API_BASE}/games/${game_id}/join`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ is_computer: true })
           })
-          const startRes = await fetch(`http://localhost:8000/games/${game_id}/start`, {
+          const startRes = await fetch(`${API_BASE}/games/${game_id}/start`, {
             method: 'POST'
           })
           const startData = await startRes.json()
@@ -229,7 +228,7 @@
         }
 
         async function newGameFriend(pseudo) {
-          const resUser = await fetch(`http://localhost:8000/users/by-username?username=${encodeURIComponent(pseudo)}`)
+          const resUser = await fetch(`${API_BASE}/users/by-username?username=${encodeURIComponent(pseudo)}`)
           if (!resUser.ok) {
             await alertApp('Utilisateur introuvable')
             return
@@ -238,24 +237,24 @@
           const resAvatar = await fetch(`${API_BASE}/users/${friendId}`)
           const friendData = await resAvatar.json()
           opponentAvatar.value = friendData.avatar_url
-          const resGame = await fetch('http://localhost:8000/games', {
+          const resGame = await fetch(`${API_BASE}/games`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({})
           })
           const { game_id } = await resGame.json()
-          const join1 = await fetch(`http://localhost:8000/games/${game_id}/join`, {
+          const join1 = await fetch(`${API_BASE}/games/${game_id}/join`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ user_id: Number(userId.value) })
           })
           const { player_id } = await join1.json()
-          await fetch(`http://localhost:8000/games/${game_id}/join`, {
+          await fetch(`${API_BASE}/games/${game_id}/join`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ user_id: friendId })
           })
-          const startRes = await fetch(`http://localhost:8000/games/${game_id}/start`, {
+          const startRes = await fetch(`${API_BASE}/games/${game_id}/start`, {
             method: 'POST'
           })
           const startData = await startRes.json()
@@ -275,7 +274,7 @@
           currentGame.value = game
           view.value = 'game'
           await Vue.nextTick()
-          const res = await fetch(`http://localhost:8000/games/${game.id}?player_id=${game.player_id}`)
+          const res = await fetch(`${API_BASE}/games/${game.id}?player_id=${game.player_id}`)
           const data = await res.json()
 
           rack.value = data.rack
@@ -300,7 +299,7 @@
 
         async function finishGame() {
           if (currentGame.value) {
-            await fetch('http://localhost:8000/finish', {
+            await fetch(`${API_BASE}/finish`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ game_id: currentGame.value.id })
@@ -393,7 +392,7 @@
           if (placements.value.length === 0) return
           const execute = async () => {
             const res = await fetch(
-              `http://localhost:8000/games/${currentGame.value.id}/play`,
+              `${API_BASE}/games/${currentGame.value.id}/play`,
               {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -425,7 +424,7 @@
               })
             }
             const stateRes = await fetch(
-              `http://localhost:8000/games/${currentGame.value.id}?player_id=${currentGame.value.player_id}`
+              `${API_BASE}/games/${currentGame.value.id}?player_id=${currentGame.value.player_id}`
             )
             const stateData = await stateRes.json()
             rack.value = stateData.rack
@@ -448,7 +447,7 @@
           clearMove()
           const execute = async () => {
             const res = await fetch(
-              `http://localhost:8000/games/${currentGame.value.id}/pass`,
+              `${API_BASE}/games/${currentGame.value.id}/pass`,
               {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -468,7 +467,7 @@
               })
             }
             const stateRes = await fetch(
-              `http://localhost:8000/games/${currentGame.value.id}?player_id=${currentGame.value.player_id}`
+              `${API_BASE}/games/${currentGame.value.id}?player_id=${currentGame.value.player_id}`
             )
             const stateData = await stateRes.json()
             rack.value = stateData.rack

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -1,17 +1,18 @@
 import { http, HttpResponse } from 'msw'
+import { API_BASE } from '../../frontend/api.js'
 
 export const handlers = [
   http.post('/games', () => HttpResponse.json({ game_id: 'g1' })),
   http.post('/games/g1/join', () => HttpResponse.json({ player_id: 'p1' })),
   http.post('/games/g1/start', () => HttpResponse.json({ ok: true })),
-  http.post('http://localhost:8000/auth/login', async ({ request }) => {
+  http.post(`${API_BASE}/auth/login`, async ({ request }) => {
     const { username } = await request.json()
     if (username === 'good') {
       return HttpResponse.json({ user_id: 'u1' })
     }
     return HttpResponse.json({ detail: 'Bad credentials' }, { status: 400 })
   }),
-  http.post('http://localhost:8000/auth/register', () =>
+  http.post(`${API_BASE}/auth/register`, () =>
     HttpResponse.json({ user_id: 'u2' })
   ),
 ]


### PR DESCRIPTION
## Summary
- centralize backend API base URL in `frontend/api.js`
- replace hardcoded `localhost:8000` calls with `API_BASE`
- update MSW test handlers to use the configurable URL

## Testing
- `npm test` *(fails: Game.vue affiche les scores joueur/adversaire)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cef9bc28832792fe26db65d26eb7