### PR TITLE
feat: derive API base URL from browser host

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,1 +1,7 @@
-export const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+const { protocol, hostname } = window.location;
+const defaultPort = hostname === 'localhost' ? '8000' : '8001';
+export const API_BASE =
+  import.meta.env.VITE_API_BASE || `${protocol}//${hostname}:${defaultPort}`;
+
+console.log('[api] protocol:', protocol, 'hostname:', hostname, 'defaultPort:', defaultPort);
+console.log('[api] using API_BASE:', API_BASE);

--- a/frontend/authHeartbeat.js
+++ b/frontend/authHeartbeat.js
@@ -6,12 +6,14 @@ export function startAuthHeartbeat() {
   stopAuthHeartbeat()
   timer = setInterval(async () => {
     try {
-      await fetch(`${API_BASE}/auth/refresh`, {
+      const url = `${API_BASE}/auth/refresh`
+      console.log('[authHeartbeat] refreshing', url)
+      await fetch(url, {
         method: 'POST',
         credentials: 'include'
       })
-    } catch {
-      // ignore
+    } catch (err) {
+      console.error('[authHeartbeat] refresh failed', err)
     }
   }, 12 * 60 * 1000)
 }


### PR DESCRIPTION
## Summary
- compute API base using browser protocol/hostname, defaulting to port 8000 for localhost and 8001 otherwise
- log derived API base and auth refresh calls for easier debugging

## Testing
- `npm test` *(fails: Game.vue affiche les scores joueur/adversaire)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c6f260ac8327828aa698278294c9