### PR TITLE
fix: allow localhost and 127.0.0.1 during dev

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from .. import models
-from ..database import get_db
+from ..database import SessionLocal, get_db
 
 # =========================================================
 # Settings (lit à partir de .env, avec compatibilité anciens noms)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,9 +18,15 @@ SECRET_KEY = os.getenv("SECRET_KEY", "dev_change_me")
 app = FastAPI()
 
 # 2) CORS en dev
+ALLOWED_ORIGINS = {
+    FRONTEND_URL,
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+}
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[FRONTEND_URL],
+    allow_origins=list(ALLOWED_ORIGINS),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow both localhost and 127.0.0.1 origins in CORS
- import SessionLocal for direct user lookup

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76abb33648327ab36da6082771ca1