### PR TITLE
refactor frontend API calls to use helpers

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -14,7 +14,7 @@ if (isProduction) {
   }
 }
 
-async function apiGet(endpoint, options = {}) {
+export async function apiGet(endpoint, options = {}) {
   return fetch(`${API_BASE}/${endpoint}`, {
     method: 'GET',
     credentials: 'include',
@@ -22,7 +22,7 @@ async function apiGet(endpoint, options = {}) {
   })
 }
 
-async function apiPost(endpoint, data, options = {}) {
+export async function apiPost(endpoint, data, options = {}) {
   const opts = {
     method: 'POST',
     credentials: 'include',
@@ -37,6 +37,10 @@ async function apiPost(endpoint, data, options = {}) {
   return fetch(`${API_BASE}/${endpoint}`, opts)
 }
 
-window.API_BASE = API_BASE
-window.apiGet = apiGet
-window.apiPost = apiPost
+export { API_BASE }
+
+if (typeof window !== 'undefined') {
+  window.API_BASE = API_BASE
+  window.apiGet = apiGet
+  window.apiPost = apiPost
+}

--- a/frontend/components/Login.vue
+++ b/frontend/components/Login.vue
@@ -79,6 +79,7 @@
 
 <script setup>
 import { ref } from 'vue'
+import { API_BASE, apiPost } from '../api.js'
 
 const emit = defineEmits(['auth'])
 
@@ -92,21 +93,11 @@ async function submit() {
   error.value = ''
   const endpoint = isRegister.value ? 'auth/register' : 'auth/login'
 
-  // if (!window.API_BASE) {
-  //   error.value = 'Configuration error: API base URL not found'
-  //   return
-  // }
-
   try {
-    const res = await fetch(`${window.API_BASE}/${endpoint}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({
-        username: username.value,
-        password: password.value,
-        remember_me: rememberMe.value
-      })
+    const res = await apiPost(endpoint, {
+      username: username.value,
+      password: password.value,
+      remember_me: rememberMe.value
     })
 
     if (!res.ok) {
@@ -128,11 +119,7 @@ function toggle() {
 }
 
 function loginGoogle() {
-  // if (!window.API_BASE) {
-  //   error.value = 'Configuration error: API base URL not found'
-  //   return
-  // }
-  window.location.href = `${window.API_BASE}/auth/google/authorize`
+  window.location.href = `${API_BASE}/auth/google/authorize`
 }
 </script>
 

--- a/frontend/components/Profile.vue
+++ b/frontend/components/Profile.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script setup>
-import { API_BASE } from '../api.js'
+import { apiGet, apiPost } from '../api.js'
 import { onMounted, ref } from 'vue'
 
 const emit = defineEmits(['back', 'logout'])
@@ -106,12 +106,12 @@ const defaultAvatars = Array.from(
 
 onMounted(async () => {
   try {
-    const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
+    const res = await apiGet('auth/me')
     if (res.ok) {
       user.value = await res.json()
       selected.value = user.value.color_palette || 'palette1'
       document.documentElement.setAttribute('data-theme', selected.value)
-      const res2 = await fetch(`${API_BASE}/games/user/${user.value.user_id}`, { credentials: 'include' })
+      const res2 = await apiGet(`games/user/${user.value.user_id}`)
       Object.assign(user.value, await res2.json())
     }
   } catch (err) {
@@ -130,11 +130,7 @@ async function onFileChange(e) {
   const form = new FormData()
   form.append('file', file)
   try {
-    const res = await fetch(`${API_BASE}/auth/me/avatar`, {
-      method: 'POST',
-      credentials: 'include',
-      body: form
-    })
+    const res = await apiPost('auth/me/avatar', form)
     if (res.ok) {
       const data = await res.json()
       if (user.value) user.value.avatar_url = data.avatar_url
@@ -148,11 +144,7 @@ async function selectAvatar(url) {
   const form = new FormData()
   form.append('choice', url.split('/').pop())
   try {
-    const res = await fetch(`${API_BASE}/auth/me/avatar`, {
-      method: 'POST',
-      credentials: 'include',
-      body: form
-    })
+    const res = await apiPost('auth/me/avatar', form)
     if (res.ok) {
       const data = await res.json()
       if (user.value) user.value.avatar_url = data.avatar_url
@@ -165,12 +157,7 @@ async function selectAvatar(url) {
 async function updatePalette() {
   document.documentElement.setAttribute('data-theme', selected.value)
   try {
-    await fetch(`${API_BASE}/auth/me/palette`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ palette: selected.value })
-    })
+    await apiPost('auth/me/palette', { palette: selected.value })
     if (user.value) user.value.color_palette = selected.value
   } catch (err) {
     console.error('Erreur mise à jour palette:', err)
@@ -183,10 +170,7 @@ async function deleteAccount() {
     return
   }
   try {
-    await fetch(`${API_BASE}/me/deletion-request`, {
-      method: 'POST',
-      credentials: 'include',
-    })
+    await apiPost('me/deletion-request')
     emit('logout')
     await window.appAlert('Demande de suppression enregistrée')
   } catch (err) {

--- a/frontend/components/Settings.vue
+++ b/frontend/components/Settings.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup>
-import { API_BASE } from '../api.js'
+import { apiGet, apiPost } from '../api.js'
 import { ref, onMounted } from 'vue'
 
 const emit = defineEmits(['back'])
@@ -21,7 +21,7 @@ const selected = ref('palette1')
 
 onMounted(async () => {
   try {
-    const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
+    const res = await apiGet('auth/me')
     if (res.ok) {
       const data = await res.json()
       selected.value = data.color_palette || 'palette1'
@@ -35,12 +35,7 @@ onMounted(async () => {
 async function updatePalette() {
   document.documentElement.setAttribute('data-theme', selected.value)
   try {
-    await fetch(`${API_BASE}/auth/me/palette`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ palette: selected.value })
-    })
+    await apiPost('auth/me/palette', { palette: selected.value })
   } catch (err) {
     console.error('Erreur mise à jour palette:', err)
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,7 +31,7 @@
     document.addEventListener('visibilitychange', async () => {
       if (document.visibilityState === 'visible') {
         try {
-          await fetch(`${API_BASE}/auth/refresh`, { method: 'POST', credentials: 'include' })
+          await window.apiPost('auth/refresh')
         } catch {
           // ignore
         }
@@ -144,15 +144,29 @@
           let lastError;
 
           for (let i = 0; i < maxRetries; i++) {
-            const controller = new AbortController(); const timeoutId = setTimeout(() =>
-              controller.abort(), timeout);
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+            const { method = 'GET', body, ...rest } = options;
+            const opts = { ...rest, signal: controller.signal };
 
             try {
-              const response = await fetch(url, {
-                ...options,
-                signal: controller.signal,
-                credentials: 'include'
-              });
+              let response;
+              if (API_BASE && url.startsWith(API_BASE) && (method === 'GET' || method === 'POST')) {
+                const endpoint = url.slice(API_BASE.length + 1);
+                if (method === 'POST') {
+                  response = await window.apiPost(endpoint, body, opts);
+                } else {
+                  response = await window.apiGet(endpoint, opts);
+                }
+              } else {
+                response = await fetch(url, {
+                  method,
+                  body,
+                  ...opts,
+                  credentials: 'include'
+                });
+              }
               clearTimeout(timeoutId);
               return response;
             } catch (error) {
@@ -160,10 +174,8 @@
               lastError = error;
               console.warn(`Attempt ${i + 1} failed for ${url}:`, error.message);
 
-              // Si c'est la dernière tentative, on lance l'erreur
               if (i === maxRetries - 1) break;
 
-              // Attendre avant de retry (backoff exponentiel)
               await new Promise(resolve => setTimeout(resolve, Math.pow(2, i) * 1000));
             }
           }

--- a/frontend/public/authHeartbeat.js
+++ b/frontend/public/authHeartbeat.js
@@ -4,12 +4,8 @@ function startAuthHeartbeat() {
   stopAuthHeartbeat()
   timer = setInterval(async () => {
     try {
-      const url = `${API_BASE}/auth/refresh`
-      console.log('[authHeartbeat] refreshing', url)
-      await fetch(url, {
-        method: 'POST',
-        credentials: 'include'
-      })
+      console.log('[authHeartbeat] refreshing')
+      await apiPost('auth/refresh')
     } catch (err) {
       console.error('[authHeartbeat] refresh failed', err)
     }

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -1,18 +1,16 @@
 import { http, HttpResponse } from 'msw'
-import { API_BASE } from '../../frontend/public/api.js'
-
 export const handlers = [
   http.post('/games', () => HttpResponse.json({ game_id: 'g1' })),
   http.post('/games/g1/join', () => HttpResponse.json({ player_id: 'p1' })),
   http.post('/games/g1/start', () => HttpResponse.json({ ok: true })),
-  http.post(`${API_BASE}/auth/login`, async ({ request }) => {
+  http.post('http://localhost:8000/auth/login', async ({ request }) => {
     const { username } = await request.json()
     if (username === 'good') {
       return HttpResponse.json({ user_id: 'u1' })
     }
     return HttpResponse.json({ detail: 'Bad credentials' }, { status: 400 })
   }),
-  http.post(`${API_BASE}/auth/register`, () =>
+  http.post('http://localhost:8000/auth/register', () =>
     HttpResponse.json({ user_id: 'u2' })
   ),
 ]


### PR DESCRIPTION
## Summary
- add apiGet and apiPost helpers and expose them globally
- refactor frontend components and utilities to call apiGet/apiPost
- update tests to match new API helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f4f353b483279ccf8a4ca883d3b5